### PR TITLE
Configure Binder Badge workflow to test on binder.pangeo.io

### DIFF
--- a/.github/workflows/binder.yaml
+++ b/.github/workflows/binder.yaml
@@ -23,7 +23,7 @@ jobs:
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            body: `[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/${PR_HEAD_USERREPO}/${PR_HEAD_REF}) :point_left: Test this PR on Binder`
+            body: `[![Binder](https://binder.pangeo.io/badge_logo.svg)](https://binder.pangeo.io/v2/gh/${PR_HEAD_USERREPO}/${PR_HEAD_REF}) :point_left: Test this PR on Pangeo Binder`
           })
       env:
         PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}

--- a/README.md
+++ b/README.md
@@ -6,10 +6,9 @@ This repository specifies the user environment for the [COESSING hub](https://co
 ### Making a change
 
 1. Make a pull request to this repository with your environment changes (edits to
-   `environment.yml`, etc). A bot will post a link to `mybinder.org` that
+   `environment.yml`, etc). A bot will post a link to `binder.pangeo.io` that
    can be used to test your new changes! Use it, and make sure things work the way
    you would like. If not, amend the PR until it seems right.
-   **Note:** You won't be able to test complex Dask jobs on mybinder.org!
 
 2. Merge the PR. This will kick off a [GitHub Action](https://github.com/2i2c-org/coessing-image/actions)
    to build and push the container image. We use [quay.io](https://quay.io) instead of


### PR DESCRIPTION
For Pangeo-based images, test them on `binder.pangeo.io` as opposed to `mybinder.org`, for dask capabilities.