### PR TITLE
Add French language pack to env

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,3 +15,4 @@ dependencies:
   - ffmpeg
   - sqlalchemy<1.4
   - graphviz
+  - jupyterlab-language-pack-fr-FR


### PR DESCRIPTION
Add the French language pack to JuptyerLab.

Name of package obtained here: https://github.com/jupyterlab/language-packs/tree/main/language-packs/jupyterlab-language-pack-fr-FR

Instructions to change the language found here: https://jupyterlab.readthedocs.io/en/stable/user/language.html